### PR TITLE
importing handsontable from modules as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "zeroclipboard": "^2.3.0"
   },
   "dependencies": {},
+  "peerDependencies": {
+    "handsontable": "^0.29.0"
+  },
   "scripts": {
     "test": "npm run _pre-testing && jest",
     "test:watch": "npm run _pre-testing && jest --watch",

--- a/src/handsontableSettingsMapper.js
+++ b/src/handsontableSettingsMapper.js
@@ -1,3 +1,5 @@
+import Handsontable from 'handsontable';
+
 export default class HotSettingsMapper {
   constructor() {
     this.registeredHooks = Handsontable.hooks.getRegistered();

--- a/src/react-handsontable.jsx
+++ b/src/react-handsontable.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import HotSettingsMapper from './handsontableSettingsMapper';
+import Handsontable from 'handsontable';
 
 /**
  * A Handsontable-ReactJS wrapper.


### PR DESCRIPTION
Importing handsontable is now possible as the component is demanding handsontable as a peer dependency.