### PR TITLE
Modify the autoSize warning-throwing function.

### DIFF
--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -4,6 +4,12 @@ import ReactDOM from 'react-dom';
 let bulkComponentContainer = null;
 
 /**
+ * Warning message for the `autoRowSize`/`autoColumnSize` compatibility check.
+ */
+export const AUTOSIZE_WARNING = 'Your `HotTable` configuration includes `autoRowSize`/`autoColumnSize` options, which are not compatible with ' +
+  ' the component-based renderers`. Disable `autoRowSize` and `autoColumnSize` to prevent row and column misalignment.';
+
+/**
  * Filter out and return elements of the provided `type` from the `HotColumn` component's children.
  *
  * @param {React.ReactNode} children HotTable children array.

--- a/src/hotColumn.tsx
+++ b/src/hotColumn.tsx
@@ -40,7 +40,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
    * @returns {Object}
    */
   getSettingsProps(): HotTableProps {
-    this.internalProps = ['_emitColumnSettings', '_columnIndex', '_getChildElementByType', '_getRendererWrapper',
+    this.internalProps = ['__componentRendererColumns', '_emitColumnSettings', '_columnIndex', '_getChildElementByType', '_getRendererWrapper',
       '_getEditorClass', '_getEditorCache', 'hot-renderer', 'hot-editor', 'children'];
 
     return Object.keys(this.props)
@@ -84,6 +84,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
 
     if (rendererElement !== null) {
       this.columnSettings.renderer = this.props._getRendererWrapper(rendererElement);
+      this.props._componentRendererColumns.set(this.props._columnIndex, true);
 
     } else if (this.hasProp('renderer')) {
       this.columnSettings.renderer = this.props.renderer;

--- a/src/hotTable.tsx
+++ b/src/hotTable.tsx
@@ -15,6 +15,7 @@ import {
   addUnsafePrefixes,
   removeEditorContainers
 } from './helpers';
+import { warn } from 'handsontable/commonjs/helpers/console';
 
 /**
  * A Handsontable-ReactJS wrapper.
@@ -370,7 +371,7 @@ class HotTable extends React.Component<HotTableProps, {}> {
   displayAutoSizeWarning(newGlobalSettings: Handsontable.GridSettings): void {
     if (this.hotInstance.getPlugin('autoRowSize').enabled || this.hotInstance.getPlugin('autoColumnSize').enabled) {
       if (this.componentRendererColumns.size > 0) {
-        console.warn(AUTOSIZE_WARNING);
+        warn(AUTOSIZE_WARNING);
       }
     }
   }

--- a/src/hotTable.tsx
+++ b/src/hotTable.tsx
@@ -6,6 +6,7 @@ import { HotColumn } from './hotColumn';
 import * as packageJson from '../package.json';
 import { HotTableProps } from './types';
 import {
+  AUTOSIZE_WARNING,
   createEditorPortal,
   createPortal,
   getChildElementByType,
@@ -347,7 +348,7 @@ class HotTable extends React.Component<HotTableProps, {}> {
       newSettings.editor = this.getEditorClass(globalEditorNode);
 
     } else {
-      newSettings.editor = this.props.editor || this.props.settings ? this.props.settings.editor : void 0;
+      newSettings.editor = this.props.editor || (this.props.settings ? this.props.settings.editor : void 0);
     }
 
     if (globalRendererNode) {
@@ -355,7 +356,7 @@ class HotTable extends React.Component<HotTableProps, {}> {
       this.componentRendererColumns.set('global', true);
 
     } else {
-      newSettings.renderer = this.props.renderer || this.props.settings ? this.props.settings.renderer : void 0;
+      newSettings.renderer = this.props.renderer || (this.props.settings ? this.props.settings.renderer : void 0);
     }
 
     return newSettings;
@@ -369,8 +370,7 @@ class HotTable extends React.Component<HotTableProps, {}> {
   displayAutoSizeWarning(newGlobalSettings: Handsontable.GridSettings): void {
     if (this.hotInstance.getPlugin('autoRowSize').enabled || this.hotInstance.getPlugin('autoColumnSize').enabled) {
       if (this.componentRendererColumns.size > 0) {
-        console.warn('Your `HotTable` configuration includes `autoRowSize`/`autoColumnSize` options, which are not compatible with ' +
-          ' the component-based renderers`. Disable `autoRowSize` and `autoColumnSize` to prevent row and column misalignment.');
+        console.warn(AUTOSIZE_WARNING);
       }
     }
   }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -18,6 +18,7 @@ export interface HotTableProps extends Handsontable.GridSettings {
  * Properties related to the HotColumn architecture.
  */
 export interface HotColumnProps extends Handsontable.GridSettings {
+  _componentRendererColumns?: Map<number | string, boolean>;
   _emitColumnSettings?: (columnSettings: Handsontable.GridSettings, columnIndex: number) => void;
   _columnIndex?: number,
   _getChildElementByType?: (children: React.ReactNode, type: string) => React.ReactElement;

--- a/test/_helpers.tsx
+++ b/test/_helpers.tsx
@@ -65,7 +65,13 @@ class IndividualPropsWrapper extends React.Component<{ref?: string, id?: string}
   render(): React.ReactElement {
     return (
       <div>
-        <HotTable licenseKey="non-commercial-and-evaluation" ref={this.setHotElementRef.bind(this)} id="hot" {...this.state.hotSettings} />
+        <HotTable
+          licenseKey="non-commercial-and-evaluation"
+          ref={this.setHotElementRef.bind(this)}
+          id="hot" {...this.state.hotSettings}
+          autoRowSize={false}
+          autoColumnSize={false}
+        />
       </div>
     );
   }
@@ -91,7 +97,14 @@ class SingleObjectWrapper extends React.Component<{ref?: string, id?: string}, {
   render(): React.ReactElement {
     return (
       <div>
-        <HotTable licenseKey="non-commercial-and-evaluation" ref={this.setHotElementRef.bind(this)} id="hot" settings={this.state.hotSettings}/>
+        <HotTable
+          licenseKey="non-commercial-and-evaluation"
+          ref={this.setHotElementRef.bind(this)}
+          id="hot"
+          settings={this.state.hotSettings}
+          autoRowSize={false}
+          autoColumnSize={false}
+        />
       </div>
     );
   }

--- a/test/autoSizeWarning.spec.tsx
+++ b/test/autoSizeWarning.spec.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import {
+  mount,
+  ReactWrapper
+} from 'enzyme';
+import {
+  HotTable
+} from '../src/hotTable';
+import {
+  HotColumn
+} from '../src/hotColumn';
+import {
+  mockElementDimensions,
+  sleep
+} from './_helpers';
+import {
+  AUTOSIZE_WARNING
+} from '../src/helpers';
+import Handsontable from 'handsontable';
+
+beforeEach(() => {
+  let container = document.createElement('DIV');
+  container.id = 'hotContainer';
+  document.body.appendChild(container);
+});
+
+describe('`autoRowSize`/`autoColumns` warning', () => {
+  it('should recognize whether `autoRowSize` or `autoColumnSize` is enabled and throw a warning, if a global component-based renderer' +
+    'is defined', async (done) => {
+    console.warn = jasmine.createSpy('warn');
+
+    const RendererComponent = function (props) {
+      return <>test</>
+    };
+
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={Handsontable.helper.createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <RendererComponent hot-renderer></RendererComponent>
+      </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+
+    await sleep(100);
+
+    expect(console.warn).toHaveBeenCalledWith(AUTOSIZE_WARNING);
+
+    wrapper.detach();
+    done();
+  });
+
+  it('should recognize whether `autoRowSize` or `autoColumnSize` is enabled and throw a warning, if a component-based renderer' +
+    'is defined for any column', async (done) => {
+    console.warn = jasmine.createSpy('warn');
+
+    const RendererComponent = function (props) {
+      return <>test</>
+    };
+
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={Handsontable.helper.createSpreadsheetData(3, 3)}
+                width={300}
+                height={300}
+                autoColumnSize={false}
+                autoRowSize={true}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn>
+          <RendererComponent hot-renderer></RendererComponent>
+        </HotColumn>
+        <HotColumn/>
+      </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+
+    await sleep(100);
+
+    expect(console.warn).toHaveBeenCalledWith(AUTOSIZE_WARNING);
+
+    wrapper.detach();
+    done();
+  });
+
+  it('should throw a warning, when `autoRowSize` or `autoColumnSize` is defined, and both function-based and component-based renderers are defined', async (done) => {
+    console.warn = jasmine.createSpy('warn');
+
+    const RendererComponent = function (props) {
+      return <>test</>
+    };
+
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={Handsontable.helper.createSpreadsheetData(3, 3)}
+                width={300}
+                height={300}
+                columns={function(columnIndex) {
+                  return {
+                    renderer: function() {}
+                  }
+                }}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn>
+          <RendererComponent hot-renderer/>
+        </HotColumn>
+        <HotColumn/>
+      </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+
+    await sleep(100);
+
+    expect(console.warn).toHaveBeenCalledWith(AUTOSIZE_WARNING);
+
+    wrapper.detach();
+    done();
+  });
+
+  it('should NOT throw any warnings, when `autoRowSize` or `autoColumnSize` is defined, but only global function-based renderers were defined', async (done) => {
+    console.warn = jasmine.createSpy('warn');
+
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={Handsontable.helper.createSpreadsheetData(3, 3)}
+                width={300}
+                height={300}
+                renderer={function() {}}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn/>
+        <HotColumn/>
+      </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+
+    await sleep(100);
+
+    expect(console.warn).not.toHaveBeenCalled();
+
+    wrapper.detach();
+    done();
+  });
+
+  it('should NOT throw any warnings, when `autoRowSize` or `autoColumnSize` is defined, but only function-based renderers were defined for columns', async (done) => {
+    console.warn = jasmine.createSpy('warn');
+
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={Handsontable.helper.createSpreadsheetData(3, 3)}
+                width={300}
+                height={300}
+                columns={[{renderer: function() {}}]}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn/>
+        <HotColumn/>
+      </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+
+    await sleep(100);
+
+    expect(console.warn).not.toHaveBeenCalled();
+
+    wrapper.detach();
+    done();
+  });
+
+  it('should NOT throw any warnings, when `autoRowSize` or `autoColumnSize` is defined, but only function-based renderers were defined for columns, when ' +
+    'the `columns` option is defined as a function', async (done) => {
+    console.warn = jasmine.createSpy('warn');
+
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={Handsontable.helper.createSpreadsheetData(3, 3)}
+                width={300}
+                height={300}
+                columns={function(columnIndex) {
+                  return {
+                    renderer: function() {}
+                  }
+                }}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn/>
+        <HotColumn/>
+      </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+
+    await sleep(100);
+
+    expect(console.warn).not.toHaveBeenCalled();
+
+    wrapper.detach();
+    done();
+  });
+});

--- a/test/autoSizeWarning.spec.tsx
+++ b/test/autoSizeWarning.spec.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 describe('`autoRowSize`/`autoColumns` warning', () => {
   it('should recognize whether `autoRowSize` or `autoColumnSize` is enabled and throw a warning, if a global component-based renderer' +
-    'is defined', async (done) => {
+    'is defined (using the default Handsontable settings - autoColumnSize is enabled by default)', async (done) => {
     console.warn = jasmine.createSpy('warn');
 
     const RendererComponent = function (props) {
@@ -43,6 +43,70 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>
         <RendererComponent hot-renderer></RendererComponent>
+      </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+
+    await sleep(100);
+
+    expect(console.warn).toHaveBeenCalledWith(AUTOSIZE_WARNING);
+
+    wrapper.detach();
+    done();
+  });
+
+  it('should recognize whether `autoRowSize` or `autoColumnSize` is enabled and throw a warning, if a global component-based renderer' +
+    'is defined', async (done) => {
+    console.warn = jasmine.createSpy('warn');
+
+    const RendererComponent = function (props) {
+      return <>test</>
+    };
+
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={Handsontable.helper.createSpreadsheetData(3, 2)}
+                width={300}
+                height={300}
+                autoRowSize={false}
+                autoColumnSize={true}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <RendererComponent hot-renderer></RendererComponent>
+      </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+
+    await sleep(100);
+
+    expect(console.warn).toHaveBeenCalledWith(AUTOSIZE_WARNING);
+
+    wrapper.detach();
+    done();
+  });
+
+  it('should recognize whether `autoRowSize` or `autoColumnSize` is enabled and throw a warning, if a component-based renderer' +
+    'is defined for any column (using the default Handsontable settings - autoColumnSize enabled by default)', async (done) => {
+    console.warn = jasmine.createSpy('warn');
+
+    const RendererComponent = function (props) {
+      return <>test</>
+    };
+
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={Handsontable.helper.createSpreadsheetData(3, 3)}
+                width={300}
+                height={300}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn>
+          <RendererComponent hot-renderer></RendererComponent>
+        </HotColumn>
+        <HotColumn/>
       </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
     );
 
@@ -102,6 +166,8 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                 data={Handsontable.helper.createSpreadsheetData(3, 3)}
                 width={300}
                 height={300}
+                autoRowSize={false}
+                autoColumnSize={true}
                 columns={function(columnIndex) {
                   return {
                     renderer: function() {}
@@ -135,6 +201,8 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                 data={Handsontable.helper.createSpreadsheetData(3, 3)}
                 width={300}
                 height={300}
+                autoRowSize={true}
+                autoColumnSize={false}
                 renderer={function() {}}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
@@ -162,6 +230,8 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                 data={Handsontable.helper.createSpreadsheetData(3, 3)}
                 width={300}
                 height={300}
+                autoRowSize={true}
+                autoColumnSize={true}
                 columns={[{renderer: function() {}}]}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
@@ -190,6 +260,8 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                 data={Handsontable.helper.createSpreadsheetData(3, 3)}
                 width={300}
                 height={300}
+                autoRowSize={false}
+                autoColumnSize={true}
                 columns={function(columnIndex) {
                   return {
                     renderer: function() {}

--- a/test/componentInternals.spec.tsx
+++ b/test/componentInternals.spec.tsx
@@ -54,6 +54,8 @@ describe('Subcomponent state', () => {
                 height={300}
                 rowHeights={23}
                 colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>
@@ -212,6 +214,8 @@ describe('Component lifecyle', () => {
                 height={300}
                 rowHeights={23}
                 colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>

--- a/test/hotColumn.spec.tsx
+++ b/test/hotColumn.spec.tsx
@@ -24,7 +24,11 @@ beforeEach(() => {
 describe('Passing column settings using HotColumn', () => {
   it('should apply the Handsontable settings passed as HotColumn arguments to the Handsontable instance', async (done) => {
     const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
-      <HotTable licenseKey="non-commercial-and-evaluation" id="test-hot" data={[[2]]} readOnly={false}>
+      <HotTable
+        licenseKey="non-commercial-and-evaluation"
+        id="test-hot" data={[[2]]}
+        readOnly={false}
+      >
         <HotColumn title="test title"></HotColumn>
         <HotColumn readOnly={true}></HotColumn>
       </HotTable>, {attachTo: document.body.querySelector('#hotContainer')}
@@ -58,6 +62,8 @@ describe('Renderer configuration using React components', () => {
                 height={300}
                 rowHeights={23}
                 colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>
@@ -175,6 +181,8 @@ describe('Dynamic HotColumn configuration changes', () => {
                     rowHeights={23}
                     colWidths={50}
                     readOnly={false}
+                    autoRowSize={false}
+                    autoColumnSize={false}
                     init={function () {
                       mockElementDimensions(this.rootElement, 300, 300);
                     }}

--- a/test/hotTable.spec.tsx
+++ b/test/hotTable.spec.tsx
@@ -27,8 +27,11 @@ beforeEach(() => {
 describe('Handsontable initialization', () => {
   it('should render Handsontable when using the HotTable component', async (done) => {
     const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
-      <HotTable id="test-hot" data={[[2]]}
-                licenseKey="non-commercial-and-evaluation"/>, {attachTo: document.body.querySelector('#hotContainer')}
+      <HotTable
+        id="test-hot"
+        data={[[2]]}
+        licenseKey="non-commercial-and-evaluation"
+      />, {attachTo: document.body.querySelector('#hotContainer')}
     );
 
     await sleep(300);
@@ -47,9 +50,13 @@ describe('Handsontable initialization', () => {
 
   it('should pass the provided properties to the Handsontable instance', async (done) => {
     const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
-      <HotTable id="test-hot" contextMenu={true} rowHeaders={true} colHeaders={true}
-                data={[[2]]}
-                licenseKey="non-commercial-and-evaluation"/>, {attachTo: document.body.querySelector('#hotContainer')}
+      <HotTable
+        id="test-hot"
+        contextMenu={true}
+        rowHeaders={true}
+        colHeaders={true}
+        data={[[2]]}
+        licenseKey="non-commercial-and-evaluation"/>, {attachTo: document.body.querySelector('#hotContainer')}
     );
 
     await sleep(300);
@@ -169,6 +176,8 @@ describe('Renderer configuration using React components', () => {
                 height={300}
                 rowHeights={23}
                 colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>

--- a/test/reactContext.spec.tsx
+++ b/test/reactContext.spec.tsx
@@ -76,6 +76,8 @@ describe('React Context', () => {
                   height={300}
                   rowHeights={23}
                   colWidths={50}
+                  autoRowSize={false}
+                  autoColumnSize={false}
                   init={function () {
                     mockElementDimensions(this.rootElement, 300, 300);
                   }}

--- a/test/reactHooks.spec.tsx
+++ b/test/reactHooks.spec.tsx
@@ -43,6 +43,8 @@ describe('Using hooks within HotTable renderers', () => {
                 height={300}
                 rowHeights={23}
                 colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>

--- a/test/reactLazy.spec.tsx
+++ b/test/reactLazy.spec.tsx
@@ -53,6 +53,8 @@ describe('React.lazy', () => {
                 height={300}
                 rowHeights={23}
                 colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>

--- a/test/reactMemo.spec.tsx
+++ b/test/reactMemo.spec.tsx
@@ -42,6 +42,8 @@ describe('React.memo', () => {
                 height={300}
                 rowHeights={23}
                 colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>

--- a/test/reactPureComponent.spec.tsx
+++ b/test/reactPureComponent.spec.tsx
@@ -42,6 +42,8 @@ describe('React PureComponents', () => {
                 height={300}
                 rowHeights={23}
                 colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>

--- a/test/redux.spec.tsx
+++ b/test/redux.spec.tsx
@@ -72,6 +72,8 @@ describe('Using Redux store within HotTable renderers and editors', () => {
                   height={300}
                   rowHeights={23}
                   colWidths={50}
+                  autoRowSize={false}
+                  autoColumnSize={false}
                   init={function () {
                     mockElementDimensions(this.rootElement, 300, 300);
                   }}>


### PR DESCRIPTION
### Context
The current `displayAutoSizeWarning` method uses the `columns` option, but doesn't work properly when it's defined as a `function`.
This PR changes the approach for checking whether any component-based renderers were declared.

### How has this been tested?
Added test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #141 
