### PR TITLE
Fix a problem with missing types for HotTable and HotColumn.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4173,9 +4173,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -150,7 +150,7 @@ export function createPortal(rElement: React.ReactElement, props, callback: Func
  * @param {Function} Klass Class to have the methods renamed.
  * @returns {Function} Class with the renamed methods.
  */
-export function addUnsafePrefixes(Klass) {
+export function addUnsafePrefixes(Klass): typeof Klass {
   const reactSemverArray = React.version.split('.').map((v) => parseInt(v));
   const shouldPrefix = reactSemverArray[0] >= 16 && reactSemverArray[1] >= 3;
 

--- a/src/hotColumn.tsx
+++ b/src/hotColumn.tsx
@@ -174,5 +174,5 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
   }
 }
 
-const PrefixedHotColumn = addUnsafePrefixes(HotColumn);
+const PrefixedHotColumn: typeof HotColumn = addUnsafePrefixes(HotColumn);
 export { PrefixedHotColumn as HotColumn };

--- a/src/hotTable.tsx
+++ b/src/hotTable.tsx
@@ -532,6 +532,6 @@ class HotTable extends React.Component<HotTableProps, {}> {
   }
 }
 
-const PrefixedHotTable = addUnsafePrefixes(HotTable);
+const PrefixedHotTable: typeof HotTable = addUnsafePrefixes(HotTable);
 export default PrefixedHotTable;
 export { PrefixedHotTable as HotTable };


### PR DESCRIPTION
### Context
Because the `addUnsafePrefixes` function returned a class with no type defined, all of the types for `HotTable` and `HotColumn` were missing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #144 