### PR TITLE
Bugfix for Typescript type fwding

### DIFF
--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -150,7 +150,7 @@ export function createPortal(rElement: React.ReactElement, props, callback: Func
  * @param {Function} Klass Class to have the methods renamed.
  * @returns {Function} Class with the renamed methods.
  */
-export function addUnsafePrefixes(Klass) {
+export function addUnsafePrefixes<T extends any>(Klass: T): T {
   const reactSemverArray = React.version.split('.').map((v) => parseInt(v));
   const shouldPrefix = reactSemverArray[0] >= 16 && reactSemverArray[1] >= 3;
 


### PR DESCRIPTION
### Context
Because the `addUnsafePrefixes` function returned a class with no type defined, all of the types for `HotTable` and `HotColumn` are missing.

> Note: This is a slightly less verbose approach than #145 from @jansiegel (😍) that uses generics to properly forward the original type rather than require casting results everywhere.

### How has this been tested?
- [ ] Verified type files now include proper types after build

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #144 - 3.1.0 Erases most Typescript definitions

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
