### PR TITLE
Move the 'warn' helper to the repo.

### DIFF
--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -10,6 +10,17 @@ export const AUTOSIZE_WARNING = 'Your `HotTable` configuration includes `autoRow
   ' the component-based renderers`. Disable `autoRowSize` and `autoColumnSize` to prevent row and column misalignment.';
 
 /**
+ * Logs warn to the console if the `console` object is exposed.
+ *
+ * @param {...*} args Values which will be logged.
+ */
+export function warn(...args) {
+  if (typeof console !== 'undefined') {
+    console.warn(...args);
+  }
+}
+
+/**
  * Filter out and return elements of the provided `type` from the `HotColumn` component's children.
  *
  * @param {React.ReactNode} children HotTable children array.

--- a/src/hotTable.tsx
+++ b/src/hotTable.tsx
@@ -13,9 +13,9 @@ import {
   getComponentNodeName,
   getExtendedEditorElement,
   addUnsafePrefixes,
-  removeEditorContainers
+  removeEditorContainers,
+  warn
 } from './helpers';
-import { warn } from 'handsontable/commonjs/helpers/console';
 
 /**
  * A Handsontable-ReactJS wrapper.


### PR DESCRIPTION
### Context
Since `3.1.1` all the builds contained `core-js` and `moment.js` because of an imported function from `Handsontable`. This also caused the `.min.js` UMD builds to fail.

This change moves the function to the wrapper's internal helper file to avoid future problems.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)